### PR TITLE
Add ASU Search toggle to Customizer

### DIFF
--- a/inc/customizer.php
+++ b/inc/customizer.php
@@ -967,7 +967,7 @@ function wordpress_asu_customize_register( $wp_customize ) {
   $wp_customize->add_section(
     'wordpress_asu_theme_section_asu_search',
     array(
-      'title'      => __( 'ASU Search Replaces WP Search','asu_wordpress' ),
+      'title'      => __( 'ASU Search','asu_wordpress' ),
       'priority'   => 70,
     )
   );

--- a/inc/customizer.php
+++ b/inc/customizer.php
@@ -960,6 +960,44 @@ function wordpress_asu_customize_register( $wp_customize ) {
 
   //  =============================
   //  =============================
+  //  = ASU Search Section        =
+  //  =============================
+  //  =============================
+
+  $wp_customize->add_section(
+    'wordpress_asu_theme_section_asu_search',
+    array(
+      'title'      => __( 'ASU Search Replaces WP Search','asu_wordpress' ),
+      'priority'   => 70,
+    )
+  );
+
+  $wp_customize->add_setting(
+    'wordpress_asu_theme_options[asu_search]',
+    array(
+      'default'           => 'enable',
+      'capability'        => 'edit_theme_options',
+      'type'              => 'option',
+      'sanitize_callback' => 'wordpress_asu_sanitize_nothing',
+    )
+  );
+
+  $wp_customize->add_control(
+    'wordpress_asu_asu_search',
+    array(
+      'label'      => __( 'ASU Search', 'asu_wordpress' ),
+      'section'    => 'wordpress_asu_theme_section_asu_search',
+      'settings'   => 'wordpress_asu_theme_options[asu_search]',
+      'type'       => 'radio',
+      'choices'    => array(
+      'enable'  => 'enabled',
+      'disable' => 'disabled',
+      ),
+    )
+  );
+
+  //  =============================
+  //  =============================
   //  =Google Tag Manager Section =
   //  =============================
   //  =============================

--- a/inc/filters.php
+++ b/inc/filters.php
@@ -20,4 +20,22 @@ function asu_ws_search_form () {
   return $form;
 }
 
-add_filter( 'get_search_form', 'asu_ws_search_form' );
+if ( is_array( get_option( 'wordpress_asu_theme_options' ) ) ) {
+  $c_options = get_option( 'wordpress_asu_theme_options' );
+
+
+  // Do we have an asu_search setting?
+  if ( array_key_exists( 'asu_search', $c_options ) && $c_options['asu_search'] !== '' ) {
+    $asu_search = $c_options['asu_search'];
+  }
+
+  // Is ASU Search enabled? Then replace vanilla WP Search with ASU Search
+  if ( $asu_search ) {
+    if ( $asu_search <> 'disable' ) {
+      add_filter( 'get_search_form', 'asu_ws_search_form' );
+    } // else: ASU Search is disabled.
+  }
+  else { // If customize option is not present, enable tracking by default.
+    add_filter( 'get_search_form', 'asu_ws_search_form' );
+  }
+}


### PR DESCRIPTION
A new Customizer setting has been added to allow the ASU Search functionality that repalces the vanilla WordPress Search.

This allows third-party search, like Algolia, to be enabled on a site.