### PR TITLE
Fix Undefined Variable Issue

### DIFF
--- a/inc/filters.php
+++ b/inc/filters.php
@@ -35,7 +35,7 @@ if ( is_array( get_option( 'wordpress_asu_theme_options' ) ) ) {
    * so we check to ensure it has been set, and is not empty. Otherwise, the default behavior applies
    */
 
-  if ( isset( $asu_search ) && !empty( $asu_search ) ) {
+  if ( ! empty( $asu_search ) ) {
     if ( $asu_search <> 'disable' ) {
       add_filter( 'get_search_form', 'asu_ws_search_form' );
     } // else: ASU Search is disabled.

--- a/inc/filters.php
+++ b/inc/filters.php
@@ -5,16 +5,16 @@ function asu_ws_search_form () {
             <label class="hidden" for="asu_search_box">Search</label>
             <input name="site" value="default_collection" type="hidden">
             <div class="input-group">
-              <input class="form-control" value="' . get_search_query() . '" type="text" name="q" size="32" placeholder="Search ASU" id="asu_search_box" class="asu_search_box" onfocus="ASUHeader.searchFocus(this)" onblur="ASUHeader.searchBlur(this)"> 
+              <input class="form-control" value="' . get_search_query() . '" type="text" name="q" size="32" placeholder="Search ASU" id="asu_search_box" class="asu_search_box" onfocus="ASUHeader.searchFocus(this)" onblur="ASUHeader.searchBlur(this)">
               <span class="input-group-btn">
                 <input type="submit" value="Search" title="Search" class="asu_search_button btn">
               </span>
             </div>
-            <input name="sort" value="date:D:L:d1" type="hidden"> 
-            <input name="output" value="xml_no_dtd" type="hidden"> 
-            <input name="ie" value="UTF-8" type="hidden"> 
-            <input name="oe" value="UTF-8" type="hidden"> 
-            <input name="client" value="asu_frontend" type="hidden"> 
+            <input name="sort" value="date:D:L:d1" type="hidden">
+            <input name="output" value="xml_no_dtd" type="hidden">
+            <input name="ie" value="UTF-8" type="hidden">
+            <input name="oe" value="UTF-8" type="hidden">
+            <input name="client" value="asu_frontend" type="hidden">
             <input name="proxystylesheet" value="asu_frontend" type="hidden">
           </form>';
   return $form;
@@ -29,8 +29,13 @@ if ( is_array( get_option( 'wordpress_asu_theme_options' ) ) ) {
     $asu_search = $c_options['asu_search'];
   }
 
-  // Is ASU Search enabled? Then replace vanilla WP Search with ASU Search
-  if ( $asu_search ) {
+  /**
+   * Is ASU Search enabled? Then replace vanilla WP Search with ASU Search
+   * Note: if the conditional above results in false, we will NOT have an $asu_search variable here,
+   * so we check to ensure it has been set, and is not empty. Otherwise, the default behavior applies
+   */
+
+  if ( isset( $asu_search ) && !empty( $asu_search ) ) {
     if ( $asu_search <> 'disable' ) {
       add_filter( 'get_search_form', 'asu_ws_search_form' );
     } // else: ASU Search is disabled.


### PR DESCRIPTION
Added additional logic to fix an `undefined variable` warning related to the `$asu_search` option. We now check to make sure that variable has been set, and is not empty, before attempting to evaluate it. This should ensure that we have retrieved the option from the database, and set some value, before checking that value to determine which type of search to use.

