### PR TITLE
Remove WordPress Default oEmbed <link> Tags

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -443,6 +443,12 @@ function add_x_frame_options_header() {
 }
 add_action( 'send_headers', 'add_x_frame_options_header' );
 
+/**
+ * Remove oembed <link> tags from <head> so that LinkedIn previews will work
+ */
+remove_action( 'wp_head', 'wp_oembed_add_discovery_links');
+
+
 if ( ! function_exists( 'include_theme_file' ) ) {
   /** Include a file in this theme or child theme if its present in the child theme. We can't just
    * always call include with get_stylesheet_directory()."filename" because that will require that the


### PR DESCRIPTION
It appears that our LinkedIn previews have not been correct because LinkedIn will ignore the "og:title" we have set if there is also an __oEmbed__ tag to use. WordPress will, __by default__, add oEmbed tags to the`<head>` of every page. This code removes that particular action, resulting in pages that do NOT have oEmbed tags and should preview correctly when shared via LinkedIn.

More specifically, if you were to look in the `<head>` section of one of our events or news pages (or any WordPress page, really) you would see the following lines

```
<link rel="alternate" type="application/json+oembed" href="https://schoolofsustainability.asu.edu/wp-json/oembed/1.0/embed?url=https%3A%2F%2Fschoolofsustainability.asu.edu%2Fevents%2F">
<link rel="alternate" type="text/xml+oembed" href="https://schoolofsustainability.asu.edu/wp-json/oembed/1.0/embed?url=https%3A%2F%2Fschoolofsustainability.asu.edu%2Fevents%2F&amp;format=xml">
```

After applying this update, those two lines will not be there anymore. I confirmed this by unwisely applying this fix in a branch and moving the School website to that branch just long enough to test out a few URLs with LinkedIn's link validator.

I do want to point out the following:

- This only affects LinkedIn previews, as other social media sites prefer the `og:title` tag and use that value instead. My most recent update included fixes to make sure the `og:title` is the correct one, but that didn't matter to LinkedIn. The problem is that fixing LinkedIn sharing is precisely what the client is asking for
- Removing these links may mean that other sites cannot embed our content in their own sites. I'm not sure if we even want that to happen, but that's what oEmbed is for. As I understand it, removing these tags means that other sites will not be able to request the HTML needed for them to embed content from our sites (or at least it will be difficult to discover).