### PR TITLE
Master-2.2.21-Remove oEmbed Discovery Tags

### DIFF
--- a/style.css
+++ b/style.css
@@ -4,7 +4,7 @@ Theme URI: https://github.com/gios-asu/ASU-Web-Standards-Wordpress-Theme
 Author: <a href="https://sustainability.asu.edu/?utm_source=wordpress&utm_medium=theme&utm_campaign=ASU-Wordpress-Web-Standards-Theme">The Julie Ann Wrigley Global Institute of Sustainability</a>
 Author URI: http://sustainability.asu.edu
 Description: ASU Web Standards compliant Wordpress Theme, for questions and updates please use the github repository: <a href="https://github.com/gios-asu/ASU-Wordpress-Web-Standards-Theme?utm_source=wordpress&utm_medium=theme&utm_campaign=ASU-Wordpress-Web-Standards-Theme">github.com/gios-asu/ASU-Wordpress-Web-Standards-Theme</a>.
-Version: 2.2.19
+Version: 2.2.20
 License: MIT
 License URI: https://github.com/gios-asu/ASU-Web-Standards-Wordpress-Theme/blob/master/LICENSE
 Text Domain: asu-wordpress-web-standards

--- a/style.css
+++ b/style.css
@@ -4,7 +4,7 @@ Theme URI: https://github.com/gios-asu/ASU-Web-Standards-Wordpress-Theme
 Author: <a href="https://sustainability.asu.edu/?utm_source=wordpress&utm_medium=theme&utm_campaign=ASU-Wordpress-Web-Standards-Theme">The Julie Ann Wrigley Global Institute of Sustainability</a>
 Author URI: http://sustainability.asu.edu
 Description: ASU Web Standards compliant Wordpress Theme, for questions and updates please use the github repository: <a href="https://github.com/gios-asu/ASU-Wordpress-Web-Standards-Theme?utm_source=wordpress&utm_medium=theme&utm_campaign=ASU-Wordpress-Web-Standards-Theme">github.com/gios-asu/ASU-Wordpress-Web-Standards-Theme</a>.
-Version: 2.2.20
+Version: 2.2.21
 License: MIT
 License URI: https://github.com/gios-asu/ASU-Web-Standards-Wordpress-Theme/blob/master/LICENSE
 Text Domain: asu-wordpress-web-standards


### PR DESCRIPTION
Removes the oEmbed discovery tags that WordPress puts in the page `<head>`. The existence of these tags, which output incorrect information when used on our News and Events pages, was causing social media sharing on LinkedIn to render incorrect article titles, images, and links.